### PR TITLE
Fixed errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,3 @@
 
 	I created a ColoredDrawable class which extends DrawableDecorator to draw out white margins between each panels. 
-  Then I wrote DDALineRenderer, BresenhamLineRenderer, AlternatingLineRenderer, and AntialiasingLineRender in order to draw lines for first three pages. 
-  Corresponding test pages Parallelogram was made for page 2. Then RandomPolygon test was made for page 3. 
-	I have put majority of efforts on page 4 and page 5 for polygons drawing. 
-  I wrote FilledPolygonRenderer for any shape of polygons drawing. 
-  In total, I have separate polygons into 4 big categories: Horizontal Top line polygons, Horizontal Bottom line polygons, 
-  Non-horizontal lines polygons with left line shorter, Non-horizontal lines polygons with right line shorter. 
-  Among these 4 categories, I have separated 3 sub-categories for each: top/bottom vertex in middle, left or right of the other two vertices. 
-  Using a function called fillPixels_leftToRight to draw from left to right. 
-	Then corresponding polygon renderer test pages StarburstPolygonTest, MeshPolygonTest and RandomPolygonTest were made. 
-  There is a main issue that I put lots of time in but cannot fix, when turned to page 5, it is easy to see there are polygons that are overlapping. 
-  Especially in the middle of the starburstPolygon. Same thing happened to MeshpolygonTest, there were overlapping that can see visually between some horizontal lines. 
-  I first suspect the problem was caused by drawing of polygons with horizontal line. So I added if statement to fix it, 
-  but main problem still occurs. Then I suspect it is because of the rounding of double type to int type, 
-  in which lost information. However, I still cannot really fix it.
+DDALineRenderer, BresenhamLineRenderer, AlternatingLineRenderer, and AntialiasingLineRender were written next in order to draw lines for first three pages. Corresponding test pages Parallelogram was made for page 2. RandomPolygon test was made for page 3. Majority of efforts were made on page 4 and page 5 for polygons drawing. FilledPolygonRenderer for any shape of polygons drawing was written. Polygons were separated into 4 big categories: Horizontal Top line polygons, Horizontal Bottom line polygons, Non-horizontal lines polygons with left line shorter, Non-horizontal lines polygons with right line shorter. In each of these categories, 3 sub-categories were operated for each: top/bottom vertex in middle, left or right of the other two vertices. A function called fillPixels_leftToRight was used to draw from left to right. Corresponding polygon renderer test pages StarburstPolygonTest, MeshPolygonTest and RandomPolygonTest were made. The main issue that cannot be fixed is when turned to page 5, it is easy to see there are polygons that are overlapping, especially in the middle of the starburstPolygon. Same thing happened to MeshpolygonTest, there was overlapping that can see visually between some horizontal lines. I first suspect the problem was caused by drawing of polygons with horizontal line. A statement is added to fix it, however,  the main problem still occurs. Then I suspect it is because of the rounding of double type to int type, in which lost information. However, I still cannot really fix it.


### PR DESCRIPTION
-Transformed some of the active voice to passive voice just to avoid successive use of pronouns. 

-Fake coherence word “then” was deleted

-Deleted “in total”, the use of it is too small

-"Among these 4 categories” -> “In each of these categories”

-Fixed some grammar mistakes such as missing verb at sentence “using a function…"

-"there were overlapping" -> “there was overlapping”

-Changed “but” -> “however” just to look a little more technical

-Some formatting changes were made to have the paragraphs look a bit nicer